### PR TITLE
[Tyr] feat: multi-agent runner support (Codex, Gemini, Claude Code, OpenCode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ The file has two sections separated by `---` front matter delimiters:
 
 | Field | Default | Description |
 |---|---|---|
-| `command` | `claude` | Claude CLI command (can include flags, e.g. `claude --model claude-opus-4-6`) |
+| `runner` | `claude-code` | Agent backend to use: `claude-code`, `codex`, `gemini`, or `opencode`. Can be overridden per-ticket via `agent:<runner>` label. |
+| `command` | `claude` | CLI command (can include flags, e.g. `claude --model claude-opus-4-6`). When `runner` is set, defaults to the runner's binary name. |
 | `max_concurrent_agents` | `10` | Global concurrency cap — max issues running simultaneously |
 | `max_concurrent_agents_by_state` | `{}` | Per-state concurrency caps. State keys are normalized to lowercase. Example: `{"in progress": 3}` |
 | `max_turns` | `20` | Max turns per agent session before ending and scheduling a retry |
@@ -302,6 +303,31 @@ agent:
       command: claude --model claude-haiku-4-5
       prompt: "You are a rapid bug fixer. Move fast and write a test for each fix."
 ```
+
+#### Multi-Agent Support
+
+Symphony supports multiple agent backends beyond Claude Code. You can configure which agent runs globally or override per-ticket using labels.
+
+**Supported runners:**
+
+| Runner | CLI Binary | Command Example | Notes |
+|---|---|---|---|
+| `claude-code` | `claude` | `claude -p "<prompt>" --output-format stream-json` | Default. Full stream-json support, session resume via `--resume`. |
+| `codex` | `codex` | `codex --approval-mode full-auto --quiet "<prompt>"` | OpenAI Codex CLI. Plain text output. No session resume. |
+| `gemini` | `gemini` | `gemini --prompt "<prompt>"` | Google Gemini CLI. Plain text output. No session resume. |
+| `opencode` | `opencode` | `opencode --prompt "<prompt>"` | OpenCode CLI (stub — exact flags may change). |
+
+**Global configuration** in `WORKFLOW.md`:
+
+```yaml
+agent:
+  runner: codex          # use Codex for all tickets
+  # command: codex       # optional: override the binary name/path
+```
+
+**Per-ticket override** via label: add an `agent:codex`, `agent:gemini`, or `agent:opencode` label to any Linear or GitHub issue. The label takes precedence over the global `runner` setting.
+
+The TUI and web dashboard show which runner is active for each issue. Non-default runners display a badge (e.g. `[codex]`) next to the issue identifier.
 
 #### SSH Worker Hosts
 

--- a/cmd/symphony/main.go
+++ b/cmd/symphony/main.go
@@ -157,7 +157,7 @@ func run(ctx context.Context, cfg *config.Config, workflowPath string, logFile s
 	}
 
 	cfg.Agent.Command = resolveAgentCommand(cfg.Agent.Command)
-	runner := agent.NewClaudeRunner()
+	runners := agent.NewRunnerRegistry(cfg.Agent.Runner)
 	wm := workspace.NewManager(cfg)
 
 	// Remove workspaces for issues that were terminal when we last shut down.
@@ -172,7 +172,7 @@ func run(ctx context.Context, cfg *config.Config, workflowPath string, logFile s
 	if logFile != "" {
 		logBuf.SetLogDir(filepath.Join(filepath.Dir(logFile), "issues"))
 	}
-	orch := orchestrator.New(cfg, tr, runner, wm)
+	orch := orchestrator.New(cfg, tr, runners, wm)
 	if os.Getenv("SYMPHONY_DRY_RUN") == "1" {
 		orch.DryRun = true
 		slog.Info("symphony: dry-run mode enabled — agents will not be dispatched")

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -1,0 +1,158 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CodexRunner spawns an OpenAI Codex CLI subprocess (codex).
+// Codex does not emit stream-json, so output is captured as plain text.
+type CodexRunner struct{}
+
+// NewCodexRunner constructs a CodexRunner.
+func NewCodexRunner() *CodexRunner {
+	return &CodexRunner{}
+}
+
+// RunTurn runs a single codex turn as a subprocess.
+// Codex is invoked as: codex --approval-mode full-auto --quiet "<prompt>"
+// The command parameter allows overriding the binary name (default "codex").
+func (c *CodexRunner) RunTurn(
+	ctx context.Context,
+	log Logger,
+	onProgress func(TurnResult),
+	sessionID *string,
+	prompt, workspacePath, command, workerHost string,
+	readTimeoutMs, turnTimeoutMs int,
+) (TurnResult, error) {
+	turnCtx, cancel := context.WithTimeout(ctx, time.Duration(turnTimeoutMs)*time.Millisecond)
+	defer cancel()
+
+	if command == "" || command == "claude" {
+		command = "codex"
+	}
+
+	// Codex doesn't support --resume; every turn is a fresh invocation.
+	// If sessionID is set, we include context about continuation in the prompt.
+	effectivePrompt := prompt
+	if sessionID != nil && *sessionID != "" {
+		effectivePrompt = "Continue working on the previous task. " + prompt
+	}
+
+	shellCmd := buildCodexShellCmd(command, effectivePrompt)
+	var cmd *exec.Cmd
+	if workerHost != "" {
+		if workspacePath != "" {
+			shellCmd = "cd " + shellQuote(workspacePath) + " && " + shellCmd
+		}
+		cmd = exec.CommandContext(turnCtx, "ssh",
+			"-T", "-o", "BatchMode=yes",
+			workerHost,
+			"bash", "-lc", shellCmd,
+		)
+	} else if filepath.IsAbs(command) && !strings.Contains(command, " ") {
+		args := []string{"--approval-mode", "full-auto", "--quiet", effectivePrompt}
+		cmd = exec.CommandContext(turnCtx, command, args...)
+	} else {
+		cmd = exec.CommandContext(turnCtx, loginShell(), "-lc", shellCmd)
+	}
+	if workspacePath != "" && workerHost == "" {
+		cmd.Dir = workspacePath
+	}
+
+	// Pass prompt via environment to avoid shell quoting issues.
+	cmd.Env = append(os.Environ(), "CODEX_PROMPT="+effectivePrompt)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return TurnResult{Failed: true}, fmt.Errorf("codex: stdout pipe: %w", err)
+	}
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	log.Info("codex: session started", "command", command)
+
+	if err := cmd.Start(); err != nil {
+		return TurnResult{Failed: true}, fmt.Errorf("codex: start: %w", err)
+	}
+
+	// Read stdout line-by-line with idle timeout.
+	var result TurnResult
+	var textBuf strings.Builder
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	readDeadline := time.Duration(readTimeoutMs) * time.Millisecond
+
+	lineCh := make(chan string, 1)
+	doneCh := make(chan error, 1)
+	go func() {
+		for scanner.Scan() {
+			lineCh <- scanner.Text()
+		}
+		doneCh <- scanner.Err()
+	}()
+
+loop:
+	for {
+		timer := time.NewTimer(readDeadline)
+		select {
+		case <-turnCtx.Done():
+			timer.Stop()
+			result.Failed = true
+			break loop
+		case <-timer.C:
+			result.Failed = true
+			break loop
+		case line := <-lineCh:
+			timer.Stop()
+			textBuf.WriteString(line)
+			textBuf.WriteString("\n")
+			log.Info("codex: text", "text", line)
+			result.LastText = line
+			if onProgress != nil {
+				onProgress(result)
+			}
+		case scanErr := <-doneCh:
+			timer.Stop()
+			if scanErr != nil {
+				result.Failed = true
+			}
+			break loop
+		}
+	}
+
+	if waitErr := cmd.Wait(); waitErr != nil && !result.Failed {
+		result.Failed = true
+	}
+
+	if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" && result.Failed {
+		if result.FailureText != "" {
+			result.FailureText = result.FailureText + " | stderr: " + stderr
+		} else {
+			result.FailureText = stderr
+		}
+	}
+
+	fullText := strings.TrimSpace(textBuf.String())
+	if fullText != "" {
+		result.AllTextBlocks = []string{fullText}
+		result.LastText = fullText
+		result.ResultText = fullText
+	}
+
+	log.Info("codex: turn done")
+	return result, nil
+}
+
+// buildCodexShellCmd builds the shell command for codex invocation.
+func buildCodexShellCmd(command, prompt string) string {
+	return command + " --approval-mode full-auto --quiet " + shellQuote(prompt)
+}

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// GeminiRunner spawns a Google Gemini CLI subprocess.
+// Gemini CLI is invoked as: gemini -p "<prompt>"
+// Output is captured as plain text (no stream-json support).
+type GeminiRunner struct{}
+
+// NewGeminiRunner constructs a GeminiRunner.
+func NewGeminiRunner() *GeminiRunner {
+	return &GeminiRunner{}
+}
+
+// RunTurn runs a single gemini turn as a subprocess.
+// The command parameter allows overriding the binary name (default "gemini").
+func (g *GeminiRunner) RunTurn(
+	ctx context.Context,
+	log Logger,
+	onProgress func(TurnResult),
+	sessionID *string,
+	prompt, workspacePath, command, workerHost string,
+	readTimeoutMs, turnTimeoutMs int,
+) (TurnResult, error) {
+	turnCtx, cancel := context.WithTimeout(ctx, time.Duration(turnTimeoutMs)*time.Millisecond)
+	defer cancel()
+
+	if command == "" || command == "claude" {
+		command = "gemini"
+	}
+
+	// Gemini CLI doesn't support session resumption natively.
+	effectivePrompt := prompt
+	if sessionID != nil && *sessionID != "" {
+		effectivePrompt = "Continue working on the previous task. " + prompt
+	}
+
+	shellCmd := buildGeminiShellCmd(command, effectivePrompt)
+	var cmd *exec.Cmd
+	if workerHost != "" {
+		if workspacePath != "" {
+			shellCmd = "cd " + shellQuote(workspacePath) + " && " + shellCmd
+		}
+		cmd = exec.CommandContext(turnCtx, "ssh",
+			"-T", "-o", "BatchMode=yes",
+			workerHost,
+			"bash", "-lc", shellCmd,
+		)
+	} else if filepath.IsAbs(command) && !strings.Contains(command, " ") {
+		args := []string{"--prompt", effectivePrompt}
+		cmd = exec.CommandContext(turnCtx, command, args...)
+	} else {
+		cmd = exec.CommandContext(turnCtx, loginShell(), "-lc", shellCmd)
+	}
+	if workspacePath != "" && workerHost == "" {
+		cmd.Dir = workspacePath
+	}
+
+	cmd.Env = append(os.Environ(), "GEMINI_PROMPT="+effectivePrompt)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return TurnResult{Failed: true}, fmt.Errorf("gemini: stdout pipe: %w", err)
+	}
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	log.Info("gemini: session started", "command", command)
+
+	if err := cmd.Start(); err != nil {
+		return TurnResult{Failed: true}, fmt.Errorf("gemini: start: %w", err)
+	}
+
+	var result TurnResult
+	var textBuf strings.Builder
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	readDeadline := time.Duration(readTimeoutMs) * time.Millisecond
+
+	lineCh := make(chan string, 1)
+	doneCh := make(chan error, 1)
+	go func() {
+		for scanner.Scan() {
+			lineCh <- scanner.Text()
+		}
+		doneCh <- scanner.Err()
+	}()
+
+loop:
+	for {
+		timer := time.NewTimer(readDeadline)
+		select {
+		case <-turnCtx.Done():
+			timer.Stop()
+			result.Failed = true
+			break loop
+		case <-timer.C:
+			result.Failed = true
+			break loop
+		case line := <-lineCh:
+			timer.Stop()
+			textBuf.WriteString(line)
+			textBuf.WriteString("\n")
+			log.Info("gemini: text", "text", line)
+			result.LastText = line
+			if onProgress != nil {
+				onProgress(result)
+			}
+		case scanErr := <-doneCh:
+			timer.Stop()
+			if scanErr != nil {
+				result.Failed = true
+			}
+			break loop
+		}
+	}
+
+	if waitErr := cmd.Wait(); waitErr != nil && !result.Failed {
+		result.Failed = true
+	}
+
+	if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" && result.Failed {
+		if result.FailureText != "" {
+			result.FailureText = result.FailureText + " | stderr: " + stderr
+		} else {
+			result.FailureText = stderr
+		}
+	}
+
+	fullText := strings.TrimSpace(textBuf.String())
+	if fullText != "" {
+		result.AllTextBlocks = []string{fullText}
+		result.LastText = fullText
+		result.ResultText = fullText
+	}
+
+	log.Info("gemini: turn done")
+	return result, nil
+}
+
+// buildGeminiShellCmd builds the shell command for gemini invocation.
+func buildGeminiShellCmd(command, prompt string) string {
+	return command + " --prompt " + shellQuote(prompt)
+}

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// OpenCodeRunner spawns an OpenCode CLI subprocess.
+// OpenCode (https://opencode.ai) is a terminal-based AI coding agent.
+// This is a stub implementation — the CLI interface may change.
+// Invoked as: opencode --prompt "<prompt>"
+type OpenCodeRunner struct{}
+
+// NewOpenCodeRunner constructs an OpenCodeRunner.
+func NewOpenCodeRunner() *OpenCodeRunner {
+	return &OpenCodeRunner{}
+}
+
+// RunTurn runs a single opencode turn as a subprocess.
+// The command parameter allows overriding the binary name (default "opencode").
+func (o *OpenCodeRunner) RunTurn(
+	ctx context.Context,
+	log Logger,
+	onProgress func(TurnResult),
+	sessionID *string,
+	prompt, workspacePath, command, workerHost string,
+	readTimeoutMs, turnTimeoutMs int,
+) (TurnResult, error) {
+	turnCtx, cancel := context.WithTimeout(ctx, time.Duration(turnTimeoutMs)*time.Millisecond)
+	defer cancel()
+
+	if command == "" || command == "claude" {
+		command = "opencode"
+	}
+
+	effectivePrompt := prompt
+	if sessionID != nil && *sessionID != "" {
+		effectivePrompt = "Continue working on the previous task. " + prompt
+	}
+
+	shellCmd := buildOpenCodeShellCmd(command, effectivePrompt)
+	var cmd *exec.Cmd
+	if workerHost != "" {
+		if workspacePath != "" {
+			shellCmd = "cd " + shellQuote(workspacePath) + " && " + shellCmd
+		}
+		cmd = exec.CommandContext(turnCtx, "ssh",
+			"-T", "-o", "BatchMode=yes",
+			workerHost,
+			"bash", "-lc", shellCmd,
+		)
+	} else if filepath.IsAbs(command) && !strings.Contains(command, " ") {
+		args := []string{"--prompt", effectivePrompt}
+		cmd = exec.CommandContext(turnCtx, command, args...)
+	} else {
+		cmd = exec.CommandContext(turnCtx, loginShell(), "-lc", shellCmd)
+	}
+	if workspacePath != "" && workerHost == "" {
+		cmd.Dir = workspacePath
+	}
+
+	cmd.Env = append(os.Environ(), "OPENCODE_PROMPT="+effectivePrompt)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return TurnResult{Failed: true}, fmt.Errorf("opencode: stdout pipe: %w", err)
+	}
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	log.Info("opencode: session started", "command", command)
+
+	if err := cmd.Start(); err != nil {
+		return TurnResult{Failed: true}, fmt.Errorf("opencode: start: %w", err)
+	}
+
+	var result TurnResult
+	var textBuf strings.Builder
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	readDeadline := time.Duration(readTimeoutMs) * time.Millisecond
+
+	lineCh := make(chan string, 1)
+	doneCh := make(chan error, 1)
+	go func() {
+		for scanner.Scan() {
+			lineCh <- scanner.Text()
+		}
+		doneCh <- scanner.Err()
+	}()
+
+loop:
+	for {
+		timer := time.NewTimer(readDeadline)
+		select {
+		case <-turnCtx.Done():
+			timer.Stop()
+			result.Failed = true
+			break loop
+		case <-timer.C:
+			result.Failed = true
+			break loop
+		case line := <-lineCh:
+			timer.Stop()
+			textBuf.WriteString(line)
+			textBuf.WriteString("\n")
+			log.Info("opencode: text", "text", line)
+			result.LastText = line
+			if onProgress != nil {
+				onProgress(result)
+			}
+		case scanErr := <-doneCh:
+			timer.Stop()
+			if scanErr != nil {
+				result.Failed = true
+			}
+			break loop
+		}
+	}
+
+	if waitErr := cmd.Wait(); waitErr != nil && !result.Failed {
+		result.Failed = true
+	}
+
+	if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" && result.Failed {
+		if result.FailureText != "" {
+			result.FailureText = result.FailureText + " | stderr: " + stderr
+		} else {
+			result.FailureText = stderr
+		}
+	}
+
+	fullText := strings.TrimSpace(textBuf.String())
+	if fullText != "" {
+		result.AllTextBlocks = []string{fullText}
+		result.LastText = fullText
+		result.ResultText = fullText
+	}
+
+	log.Info("opencode: turn done")
+	return result, nil
+}
+
+// buildOpenCodeShellCmd builds the shell command for opencode invocation.
+func buildOpenCodeShellCmd(command, prompt string) string {
+	return command + " --prompt " + shellQuote(prompt)
+}

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RunnerKind is a typed string identifying an agent backend.
+type RunnerKind string
+
+// Well-known runner kinds.
+const (
+	RunnerClaudeCode RunnerKind = "claude-code"
+	RunnerCodex      RunnerKind = "codex"
+	RunnerGemini     RunnerKind = "gemini"
+	RunnerOpenCode   RunnerKind = "opencode"
+)
+
+// allRunnerKinds is the ordered list of valid runner kinds.
+var allRunnerKinds = []RunnerKind{RunnerClaudeCode, RunnerCodex, RunnerGemini, RunnerOpenCode}
+
+// RunnerKindFrom converts a raw string to RunnerKind, defaulting to claude-code.
+func RunnerKindFrom(s string) RunnerKind {
+	k := RunnerKind(strings.ToLower(strings.TrimSpace(s)))
+	if k.Valid() {
+		return k
+	}
+	return RunnerClaudeCode
+}
+
+// Valid returns true if k is a recognised runner kind.
+func (k RunnerKind) Valid() bool {
+	switch k {
+	case RunnerClaudeCode, RunnerCodex, RunnerGemini, RunnerOpenCode:
+		return true
+	}
+	return false
+}
+
+// RunnerKindFromLabel extracts a RunnerKind from an "agent:<runner>" label.
+// Returns the kind and true if found, or "" and false otherwise.
+func RunnerKindFromLabel(label string) (RunnerKind, bool) {
+	lower := strings.ToLower(label)
+	if !strings.HasPrefix(lower, "agent:") {
+		return "", false
+	}
+	name := strings.TrimSpace(lower[len("agent:"):])
+	k := RunnerKind(name)
+	if !k.Valid() {
+		return "", false
+	}
+	return k, true
+}
+
+// ResolveRunnerFromLabels scans issue labels for an "agent:<runner>" override.
+// Returns the runner kind if found, or empty RunnerKind if no override.
+func ResolveRunnerFromLabels(labels []string) RunnerKind {
+	for _, label := range labels {
+		if kind, ok := RunnerKindFromLabel(label); ok {
+			return kind
+		}
+	}
+	return ""
+}
+
+// RunnerRegistry maps runner kinds to Runner implementations.
+type RunnerRegistry struct {
+	runners    map[RunnerKind]Runner
+	defaultKey RunnerKind
+}
+
+// NewSingleRunnerRegistry creates a registry backed by a single Runner for all kinds.
+// Useful for testing where a FakeRunner should handle all runner kinds.
+func NewSingleRunnerRegistry(r Runner) *RunnerRegistry {
+	return &RunnerRegistry{
+		runners: map[RunnerKind]Runner{
+			RunnerClaudeCode: r,
+			RunnerCodex:      r,
+			RunnerGemini:     r,
+			RunnerOpenCode:   r,
+		},
+		defaultKey: RunnerClaudeCode,
+	}
+}
+
+// NewRunnerRegistry creates a registry pre-populated with all built-in runners.
+func NewRunnerRegistry(defaultRunner string) *RunnerRegistry {
+	dk := RunnerKindFrom(defaultRunner)
+	return &RunnerRegistry{
+		runners: map[RunnerKind]Runner{
+			RunnerClaudeCode: NewClaudeRunner(),
+			RunnerCodex:      NewCodexRunner(),
+			RunnerGemini:     NewGeminiRunner(),
+			RunnerOpenCode:   NewOpenCodeRunner(),
+		},
+		defaultKey: dk,
+	}
+}
+
+// Get returns the runner for the given kind, falling back to the default.
+func (r *RunnerRegistry) Get(kind RunnerKind) Runner {
+	if runner, ok := r.runners[kind]; ok {
+		return runner
+	}
+	return r.runners[r.defaultKey]
+}
+
+// Default returns the default runner.
+func (r *RunnerRegistry) Default() Runner {
+	return r.runners[r.defaultKey]
+}
+
+// DefaultKind returns the default runner kind.
+func (r *RunnerRegistry) DefaultKind() RunnerKind {
+	return r.defaultKey
+}
+
+// DefaultCommand returns the default CLI command for a runner kind.
+func DefaultCommand(kind RunnerKind) string {
+	switch kind {
+	case RunnerClaudeCode:
+		return "claude"
+	case RunnerCodex:
+		return "codex"
+	case RunnerGemini:
+		return "gemini"
+	case RunnerOpenCode:
+		return "opencode"
+	default:
+		return "claude"
+	}
+}
+
+// BackendName returns the display name for state/UI.
+func BackendName(kind RunnerKind) string {
+	if kind == RunnerClaudeCode {
+		return "claude"
+	}
+	if kind == "" {
+		return "claude"
+	}
+	return string(kind)
+}
+
+// ValidateRunnerName checks that a runner name string is valid.
+func ValidateRunnerName(name string) error {
+	if name == "" {
+		return nil
+	}
+	k := RunnerKind(strings.ToLower(strings.TrimSpace(name)))
+	if !k.Valid() {
+		names := make([]string, len(allRunnerKinds))
+		for i, rk := range allRunnerKinds {
+			names[i] = string(rk)
+		}
+		return fmt.Errorf("unknown agent runner %q (valid: %s)", name, strings.Join(names, ", "))
+	}
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,7 +74,10 @@ type AgentConfig struct {
 	MaxConcurrentAgentsByState map[string]int
 	MaxRetryBackoffMs          int
 	MaxTurns                   int
-	Command                    string
+	// Runner is the agent backend to use (e.g. "claude-code", "codex", "gemini", "opencode").
+	// Defaults to "claude-code". Can be overridden per-ticket via "agent:<runner>" label.
+	Runner  string
+	Command string
 	TurnTimeoutMs              int
 	ReadTimeoutMs              int
 	StallTimeoutMs             int
@@ -178,6 +181,7 @@ func fromWorkflow(wf *workflow.Workflow) *Config {
 	cfg.Agent.MaxConcurrentAgents = positiveIntField(agent, "max_concurrent_agents", 10)
 	cfg.Agent.MaxRetryBackoffMs = positiveIntField(agent, "max_retry_backoff_ms", 300000)
 	cfg.Agent.MaxTurns = positiveIntField(agent, "max_turns", 20)
+	cfg.Agent.Runner = strField(agent, "runner", "claude-code")
 	cfg.Agent.Command = strField(agent, "command", "claude")
 	cfg.Agent.TurnTimeoutMs = positiveIntField(agent, "turn_timeout_ms", 3600000)
 	cfg.Agent.ReadTimeoutMs = positiveIntField(agent, "read_timeout_ms", 30000)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -30,7 +30,7 @@ type Orchestrator struct {
 
 	cfg       *config.Config
 	tracker   tracker.Tracker
-	runner    agent.Runner
+	runners   *agent.RunnerRegistry
 	workspace *workspace.Manager // nil is safe — workspace ops skipped (useful in tests)
 	logBuf    *logbuffer.Buffer  // nil is safe — log buffering disabled
 	events    chan OrchestratorEvent
@@ -88,11 +88,15 @@ type Orchestrator struct {
 }
 
 // New constructs an Orchestrator ready to Run. wm may be nil (workspace ops skipped).
-func New(cfg *config.Config, tr tracker.Tracker, runner agent.Runner, wm *workspace.Manager) *Orchestrator {
+// runners is the multi-agent registry; if nil, a default registry (claude-code only) is created.
+func New(cfg *config.Config, tr tracker.Tracker, runners *agent.RunnerRegistry, wm *workspace.Manager) *Orchestrator {
+	if runners == nil {
+		runners = agent.NewRunnerRegistry(cfg.Agent.Runner)
+	}
 	return &Orchestrator{
 		cfg:               cfg,
 		tracker:           tr,
-		runner:            runner,
+		runners:           runners,
 		workspace:         wm,
 		events:            make(chan OrchestratorEvent, 64),
 		refresh:           make(chan struct{}, 1),
@@ -493,8 +497,13 @@ func (o *Orchestrator) runReviewerWorker(ctx context.Context, issue domain.Issue
 		workerHost = hosts[0]
 	}
 
-	result, runErr := o.runner.RunTurn(ctx, workerLog, nil, nil, renderedPrompt, wsPath,
-		o.cfg.Agent.Command, workerHost, o.cfg.Agent.ReadTimeoutMs, o.cfg.Agent.TurnTimeoutMs)
+	reviewerRunner := o.runners.Get(agent.RunnerKindFrom(o.cfg.Agent.Runner))
+	reviewerCommand := o.cfg.Agent.Command
+	if reviewerCommand == "claude" && o.cfg.Agent.Runner != "" && o.cfg.Agent.Runner != "claude-code" {
+		reviewerCommand = agent.DefaultCommand(agent.RunnerKindFrom(o.cfg.Agent.Runner))
+	}
+	result, runErr := reviewerRunner.RunTurn(ctx, workerLog, nil, nil, renderedPrompt, wsPath,
+		reviewerCommand, workerHost, o.cfg.Agent.ReadTimeoutMs, o.cfg.Agent.TurnTimeoutMs)
 
 	if runErr != nil || result.Failed {
 		workerLog.Warn("reviewer: agent turn failed", "error", runErr, "failure", result.FailureText)
@@ -960,11 +969,23 @@ func (o *Orchestrator) dispatch(ctx context.Context, state State, issue domain.I
 		}
 	}
 
+	// Resolve runner kind: check for per-ticket "agent:<runner>" label override,
+	// then fall back to global config.
+	runnerKind := agent.RunnerKind(o.cfg.Agent.Runner)
+	for _, label := range issue.Labels {
+		if kind, ok := agent.RunnerKindFromLabel(label); ok {
+			runnerKind = kind
+			slog.Info("orchestrator: per-ticket runner override from label",
+				"identifier", issue.Identifier, "runner", string(runnerKind), "label", label)
+			break
+		}
+	}
+
 	if o.DryRun {
 		workerCancel()
 		slog.Info("orchestrator: [DRY-RUN] would dispatch agent",
 			"identifier", issue.Identifier, "issue_id", issue.ID,
-			"command", agentCommand, "worker_host", workerHost)
+			"command", agentCommand, "worker_host", workerHost, "runner", string(runnerKind))
 		state.Claimed[issue.ID] = struct{}{} // claim so it doesn't re-dispatch this tick
 		return state
 	}
@@ -973,7 +994,7 @@ func (o *Orchestrator) dispatch(ctx context.Context, state State, issue domain.I
 	state.Running[issue.ID] = &RunEntry{
 		Issue:        issue,
 		WorkerHost:   workerHost,
-		Backend:      "claude",
+		Backend:      string(runnerKind),
 		StartedAt:    time.Now(),
 		RetryAttempt: &attempt,
 		WorkerCancel: workerCancel,
@@ -983,7 +1004,7 @@ func (o *Orchestrator) dispatch(ctx context.Context, state State, issue domain.I
 		o.OnDispatch(issue.ID)
 	}
 
-	go o.runWorker(workerCtx, issue, attempt, workerHost, agentCommand, profileName, skipPRCheck)
+	go o.runWorker(workerCtx, issue, attempt, workerHost, agentCommand, profileName, skipPRCheck, runnerKind)
 	return state
 }
 
@@ -1016,7 +1037,8 @@ func (o *Orchestrator) transitionToWorking(ctx context.Context, issue domain.Iss
 // profileName is the active named profile for this issue (may be ""); used to
 // exclude the current agent from its own sub-agent context in teams mode.
 // skipPRCheck bypasses the open-PR guard (used when a forced re-analysis is requested).
-func (o *Orchestrator) runWorker(ctx context.Context, issue domain.Issue, attempt int, workerHost string, agentCommand string, profileName string, skipPRCheck bool) {
+// runnerKind specifies which agent backend to use for this worker.
+func (o *Orchestrator) runWorker(ctx context.Context, issue domain.Issue, attempt int, workerHost string, agentCommand string, profileName string, skipPRCheck bool, runnerKind agent.RunnerKind) {
 	defer func() {
 		if r := recover(); r != nil {
 			err := fmt.Errorf("worker panic: %v", r)
@@ -1223,8 +1245,14 @@ func (o *Orchestrator) runWorker(ctx context.Context, issue domain.Issue, attemp
 			}
 		}
 		turnStart := time.Now()
-		result, runErr := o.runner.RunTurn(ctx, workerLog, onProgress, sessionID, renderedPrompt, wsPath,
-			agentCommand, workerHost, o.cfg.Agent.ReadTimeoutMs, o.cfg.Agent.TurnTimeoutMs)
+		workerRunner := o.runners.Get(runnerKind)
+		// Use the runner's default command if config still has "claude" but runner is different.
+		effectiveCommand := agentCommand
+		if effectiveCommand == "claude" && runnerKind != agent.RunnerClaudeCode {
+			effectiveCommand = agent.DefaultCommand(runnerKind)
+		}
+		result, runErr := workerRunner.RunTurn(ctx, workerLog, onProgress, sessionID, renderedPrompt, wsPath,
+			effectiveCommand, workerHost, o.cfg.Agent.ReadTimeoutMs, o.cfg.Agent.TurnTimeoutMs)
 
 		if result.SessionID != "" {
 			s := result.SessionID

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -35,7 +35,7 @@ func TestOrchestratorDispatchesOnTick(t *testing.T) {
 		{Type: "result", SessionID: "s1"},
 	})
 
-	orch := orchestrator.New(cfg, mt, fake, nil)
+	orch := orchestrator.New(cfg, mt, agent.NewSingleRunnerRegistry(fake), nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -64,7 +64,7 @@ func TestOrchestratorNoDuplicateDispatch(t *testing.T) {
 	// Stall = true keeps the worker goroutine blocked, so the issue stays in Running state.
 	fake := &agenttest.FakeRunner{Stall: true}
 
-	orch := orchestrator.New(cfg, mt, fake, nil)
+	orch := orchestrator.New(cfg, mt, agent.NewSingleRunnerRegistry(fake), nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
@@ -84,7 +84,7 @@ func TestCancelResumeRace(t *testing.T) {
 	fake := &agenttest.FakeRunner{Stall: true}
 
 	dir := t.TempDir()
-	orch := orchestrator.New(cfg, mt, fake, nil)
+	orch := orchestrator.New(cfg, mt, agent.NewSingleRunnerRegistry(fake), nil)
 	orch.SetPausedFile(filepath.Join(dir, "paused.json"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -117,7 +117,7 @@ func TestReviewerRespectsCancellation(t *testing.T) {
 	mt := singleIssueTracker(t, "In Review")
 	fake := &agenttest.FakeRunner{Stall: true}
 
-	orch := orchestrator.New(cfg, mt, fake, nil)
+	orch := orchestrator.New(cfg, mt, agent.NewSingleRunnerRegistry(fake), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	runDone := make(chan struct{})
@@ -147,7 +147,7 @@ func TestReanalyzeIssueRace(t *testing.T) {
 	fake := &agenttest.FakeRunner{Stall: true}
 
 	dir := t.TempDir()
-	orch := orchestrator.New(cfg, mt, fake, nil)
+	orch := orchestrator.New(cfg, mt, agent.NewSingleRunnerRegistry(fake), nil)
 	orch.SetPausedFile(filepath.Join(dir, "paused.json"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -174,7 +174,7 @@ func TestCancelIssue_NotRunning(t *testing.T) {
 	cfg := baseConfig()
 	mt := singleIssueTracker(t, "In Progress")
 	fake := &agenttest.FakeRunner{Stall: true}
-	orch := orchestrator.New(cfg, mt, fake, nil)
+	orch := orchestrator.New(cfg, mt, agent.NewSingleRunnerRegistry(fake), nil)
 	// Do not call Run — no workers are dispatched.
 
 	ok := orch.CancelIssue("ENG-99")
@@ -191,7 +191,7 @@ func TestCancelIssue_Running(t *testing.T) {
 	mt := singleIssueTracker(t, "In Progress")
 	fake := &agenttest.FakeRunner{Stall: true}
 
-	orch := orchestrator.New(cfg, mt, fake, nil)
+	orch := orchestrator.New(cfg, mt, agent.NewSingleRunnerRegistry(fake), nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -224,7 +224,7 @@ func TestDispatchReviewer_IssueNotFound(t *testing.T) {
 	cfg := baseConfig()
 	mt := tracker.NewMemoryTracker(nil, cfg.Tracker.ActiveStates, cfg.Tracker.TerminalStates)
 	fake := agenttest.NewFakeRunner(nil)
-	orch := orchestrator.New(cfg, mt, fake, nil)
+	orch := orchestrator.New(cfg, mt, agent.NewSingleRunnerRegistry(fake), nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -265,7 +265,7 @@ func TestDispatchReviewer_Success(t *testing.T) {
 		}),
 		done: done,
 	}
-	orch := orchestrator.New(cfg, mt, wrapped, nil)
+	orch := orchestrator.New(cfg, mt, agent.NewSingleRunnerRegistry(wrapped), nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()

--- a/internal/statusui/model.go
+++ b/internal/statusui/model.go
@@ -1262,8 +1262,12 @@ func (m *Model) renderLeft() string {
 				elapsed := time.Duration(h.ElapsedMs) * time.Millisecond
 				tok := fmtCount(h.TotalTokens)
 				idStr := truncate(h.Identifier, 13)
-				row := fmt.Sprintf("  %s %-13s t%-2d %5s %s",
-					statusGlyph, idStr, h.TurnCount, tok, fmtDuration(elapsed))
+				backendSuffix := ""
+				if h.Backend != "" && h.Backend != "claude-code" {
+					backendSuffix = " " + h.Backend
+				}
+				row := fmt.Sprintf("  %s %-13s t%-2d %5s %s%s",
+					statusGlyph, idStr, h.TurnCount, tok, fmtDuration(elapsed), backendSuffix)
 				if isCursor {
 					padded := fmt.Sprintf("%-*s", leftPaneWidth-2, "► "+row[2:])
 					if len(padded) > leftPaneWidth-2 {
@@ -1322,9 +1326,15 @@ func (m *Model) renderLeft() string {
 		turns := fmt.Sprintf("t%-2d", r.TurnCount)
 		tok := fmtCount(r.InputTokens + r.OutputTokens)
 
+		// Show runner backend badge when not claude-code (the default).
+		backendBadge := ""
+		if r.Backend != "" && r.Backend != "claude-code" {
+			backendBadge = " " + stylePurple.Render("["+r.Backend+"]")
+		}
+
 		if selected {
 			id := styleReverse.Render("▶ " + truncate(r.Identifier, 13))
-			row := fmt.Sprintf("%s %s %s %4s %s", id, expandMark, turns, tok, stateBadge)
+			row := fmt.Sprintf("%s %s %s %4s %s%s", id, expandMark, turns, tok, stateBadge, backendBadge)
 			padded := fmt.Sprintf("%-*s", leftPaneWidth, row)
 			if len(padded) > leftPaneWidth {
 				padded = padded[:leftPaneWidth]
@@ -1332,7 +1342,7 @@ func (m *Model) renderLeft() string {
 			add(padded)
 		} else {
 			id := styleMuted.Render("  " + truncate(r.Identifier, 13))
-			row := fmt.Sprintf("%s %s %s %4s %s", id, expandMark, turns, tok, stateBadge)
+			row := fmt.Sprintf("%s %s %s %4s %s%s", id, expandMark, turns, tok, stateBadge, backendBadge)
 			add(row)
 		}
 


### PR DESCRIPTION
## Summary

- Abstracts agent spawning behind a `RunnerRegistry` interface supporting four backends: `claude-code` (default), `codex`, `gemini`, and `opencode`
- Each runner has dedicated CLI flag handling and output parsing (stream-json for Claude, plain text for others)
- Configurable globally via `agent.runner` in WORKFLOW.md and per-ticket via `agent:<runner>` labels on Linear/GitHub issues
- TUI and web dashboard show which runner is active for each issue with a backend badge

## Changes

- **`internal/agent/registry.go`** — `RunnerRegistry` maps runner kinds to `Runner` implementations with `Get()`, `Default()`, label-based resolution
- **`internal/agent/codex.go`** — `CodexRunner` spawning `codex --approval-mode full-auto --quiet`
- **`internal/agent/gemini.go`** — `GeminiRunner` spawning `gemini --prompt`
- **`internal/agent/opencode.go`** — `OpenCodeRunner` spawning `opencode --prompt` (stub, CLI may evolve)
- **`internal/config/config.go`** — Added `Runner` field to `AgentConfig`
- **`internal/orchestrator/orchestrator.go`** — Uses `RunnerRegistry` instead of single `Runner`; resolves per-ticket runner from labels; passes correct CLI command per backend
- **`internal/statusui/model.go`** — Shows runner badge `[codex]` etc. for non-default runners in both issues and history
- **`cmd/symphony/main.go`** — Wires `RunnerRegistry` instead of `ClaudeRunner`
- **`README.md`** — Documents multi-agent support, runner table, config, and per-ticket labels

## Test plan

- [x] All existing tests pass (`go test ./internal/...`)
- [ ] Manual: set `runner: codex` in WORKFLOW.md, verify Codex CLI is invoked
- [ ] Manual: add `agent:gemini` label to a ticket, verify Gemini CLI is used for that ticket
- [ ] Manual: verify TUI shows `[codex]` badge for non-default runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)